### PR TITLE
fluentd and rsyslog support; journal input support; use rsyslog conta…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*~
+syslog-filter.conf

--- a/openshift-fluentd-syslog-journal.conf
+++ b/openshift-fluentd-syslog-journal.conf
@@ -1,0 +1,7 @@
+<source>
+  @type systemd
+  path "#{ENV['DATA_DIR']}/journal"
+  pos_file "#{ENV['DATA_DIR']}/journal.pos"
+  tag system.journal
+  read_from_head true
+</source>

--- a/openshift-fluentd-syslog-tail.conf
+++ b/openshift-fluentd-syslog-tail.conf
@@ -1,0 +1,15 @@
+<source>
+  @type tail
+  path "#{ENV['DATA_DIR']}/messages*"
+  pos_file "#{ENV['DATA_DIR']}/system.pos"
+  tag system.*
+  format multiline
+  # Begin possible multiline match: "Mmm DD HH:MM:SS "
+  format_firstline /^[A-Z][a-z]{2}\s+[0-3]?[0-9]\s+[0-2][0-9]:[0-5][0-9]:[0-6][0-9]\s/
+  # extract metadata from same line that matched format_firstline
+  format1 /^(?<time>\S+\s+\S+\s+\S+)\s+(?<host>\S+)\s+(?<ident>[\w\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?[^\:]*\:\s*(?<message>.*)$/
+  time_format %b %d %H:%M:%S
+  read_from_head true
+  keep_time_key true
+  multiline_flush_interval 1s
+</source>

--- a/openshift-fluentd.conf
+++ b/openshift-fluentd.conf
@@ -1,0 +1,115 @@
+<system>
+  log_level warn
+</system>
+
+@include syslog-input.conf
+
+<source>
+  @type tail
+  path "#{ENV['DATA_DIR']}/docker/*.log"
+  pos_file "#{ENV['DATA_DIR']}/es-containers.log.pos"
+  time_format %Y-%m-%dT%H:%M:%S
+  tag kubernetes.*
+  format json
+  keep_time_key true
+  read_from_head true
+</source>
+
+<filter system.var.log.**>
+  type record_transformer
+    enable_ruby
+    <record>
+      # if host == 'localhost' do a fqdn lookup
+      ## we pull the hostname from the host's /etc/hostname mounted at /etc/docker-hostname to correctly identify the hostname
+      hostname ${host.eql?('localhost') ? (begin; File.open('/etc/docker-hostname') { |f| f.readline }.rstrip; rescue; host; end) : host}
+
+      # tag_parts = ["system","messages-20150710"]
+      ## we want to correct the time here in cases where we are reading logs from a prior year.  By default Ruby will assume the current date for
+      ## parsing, and since syslog messages do not include the year, it will populate the year with the current year which may resolve to a future date
+      ## we attempt to use the date format used for rolled over logs 'YYYYMMDD' if possible to get the correct* year, otherwise we subtract the year by 1
+      ## *we cannot know if the year is always correct e.g. logs from 20121230 may be in the file 20130101 which would resolve to still be in the past -- 20131230
+      time ${ Time.at(time) > Time.now ? (temp_time = Time.parse(Time.at(time).to_s.gsub(Time.at(time).year.to_s, (tag_parts[1].nil? ? Time.at(time).year.to_s : tag_parts[1][9,4]) )).to_datetime.to_s; Time.parse(temp_time) > Time.now ? Time.parse(temp_time.gsub(Time.parse(temp_time).year.to_s, (Time.parse(temp_time).year - 1).to_s )).to_datetime.to_s : Time.parse(temp_time).to_datetime.to_s ) : Time.at(time).to_datetime.to_s }
+
+      #tag ${tag}_.operations_log
+      version 1.1.4
+    </record>
+    remove_keys host
+</filter>
+
+<filter system.journal>
+  type record_transformer
+  enable_ruby
+  renew_record
+  <record>
+    # if the field name begins with an uppercase letter, you have to use the record["FIELDNAME"] style
+    hostname ${_HOSTNAME.eql?('localhost') ? (begin; File.open('/etc/docker-hostname') { |f| f.readline }.rstrip; rescue; _HOSTNAME; end) : _HOSTNAME}
+    time ${Time.at(_SOURCE_REALTIME_TIMESTAMP.to_f / 1000000.0).to_datetime.rfc3339(6)}
+    ident ${record["SYSLOG_IDENTIFIER"] || record["_COMM"]}
+    message ${record["MESSAGE"]}
+    version 1.1.4
+  </record>
+</filter>
+
+# simulate this filter
+# <filter kubernetes.**>
+#   type kubernetes_metadata
+#   kubernetes_url "#{ENV['K8S_HOST_URL']}"
+#   bearer_token_file /var/run/secrets/kubernetes.io/serviceaccount/token
+#   ca_file /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+#   include_namespace_id true
+# </filter>
+<filter kubernetes.**>
+  type record_transformer
+  enable_ruby
+  <record>
+    kubernetes_namespace_name ${tag_parts[3].split('_')[1]}
+    kubernetes_namespace_id 1
+    docker_container_id ${tag_parts[3].split('_')[2].split('-')[-1]}
+    kubernetes_pod_name ${tag_parts[3].split('_')[0]}
+    kubernetes_container_name ${tag_parts[3].split('_')[2].rpartition('-')[0]}
+    kubernetes_host localhost
+  </record>
+</filter>
+
+<filter kubernetes.**>
+  type record_transformer
+  enable_ruby
+  <record>
+    hostname ${(kubernetes_host rescue nil) || File.open('/etc/docker-hostname') { |f| f.readline }.rstrip}
+    message ${log}
+    version 1.1.4
+  </record>
+  remove_keys log,stream
+</filter>
+
+<match kubernetes.**>
+      @type elasticsearch_dynamic
+      host "#{ENV['ES_HOST']}"
+      port "#{ENV['ES_PORT']}"
+      scheme http
+      index_name ${record['kubernetes_namespace_name']}.${record['kubernetes_namespace_id']}.${Time.at(time).getutc.strftime(@logstash_dateformat)}
+
+      client_key "#{ENV['ES_CLIENT_KEY']}"
+      client_cert "#{ENV['ES_CLIENT_CERT']}"
+      ca_file "#{ENV['ES_CA']}"
+
+      flush_interval 5s
+      max_retry_wait 300
+      disable_retry_limit
+</match>
+
+<match system.** **_default_** **_openshift_** **_openshift-infra_**>
+      @type elasticsearch_dynamic
+      host "#{ENV['OPS_HOST']}"
+      port "#{ENV['OPS_PORT']}"
+      scheme http
+      index_name .operations.${record['time'].nil? ? Time.at(time).getutc.strftime(@logstash_dateformat) : Time.parse(record['time']).getutc.strftime(@logstash_dateformat)}
+
+      client_key "#{ENV['OPS_CLIENT_KEY']}"
+      client_cert "#{ENV['OPS_CLIENT_CERT']}"
+      ca_file "#{ENV['OPS_CA']}"
+
+      flush_interval 5s
+      max_retry_wait 300
+      disable_retry_limit
+</match>

--- a/openshift-test.sh
+++ b/openshift-test.sh
@@ -1,0 +1,347 @@
+#!/bin/sh
+
+set -euxo pipefail
+
+testdir=`dirname $0`
+pushd $testdir
+
+USE_FLUENTD=${USE_FLUENTD:-true}
+USE_GDB=${USE_GDB:-false}
+USE_JOURNAL=${USE_JOURNAL:-false}
+
+if [ "$USE_JOURNAL" = "true" ] ; then
+    rpm -q systemd-journal-gateway || sudo dnf -y install systemd-journal-gateway || \
+        sudo yum -y install systemd-journal-gateway || {
+            echo Error: please install the package systemd-journal-gateway
+            exit 1
+        }
+fi
+
+for id in `docker ps -q` ; do
+    if [ -n "$id" ] ; then
+        docker stop $id
+    fi
+done
+for id in `docker ps -qa` ; do
+    if [ -n "$id" ] ; then
+        docker rm $id
+    fi
+done
+
+workdir=`mktemp -d`
+mkdir -p $workdir
+confdir=$workdir/config
+datadir=$workdir/data
+mkdir -p $confdir
+mkdir -p $datadir/docker
+sudo chown -R $USER $workdir
+sudo chcon -Rt svirt_sandbox_file_t $workdir
+
+orig=$workdir/orig
+result=$workdir/result
+fluentd_syslog_input=openshift-fluentd-syslog-tail.conf
+rsyslog_syslog_input=rsyslog-input-file.conf
+rsyslog_bindmount=
+if [ "$USE_JOURNAL" = "true" ] ; then
+    mkdir -p $datadir/journal
+    systemlog=$datadir/journal/messages.journal
+    fluentd_syslog_input=openshift-fluentd-syslog-journal.conf
+    rsyslog_syslog_input=rsyslog-input-journal.conf
+    rsyslog_bindmount="-v $datadir/journal:/run/log/journal"
+else
+    systemlog=$datadir/messages
+fi
+
+cleanup() {
+    out=$?
+    docker logs $collectorid > collector.log 2>&1
+    if [ -n "$workdir" -a -d "$workdir" ] ; then
+        if [ $out -ne 0 ] ; then
+            ls -R -alrtF $workdir
+        fi
+        rm -rf "$workdir"
+    fi
+}
+
+trap "exit" INT TERM
+trap "cleanup" EXIT
+
+wait_until_cmd() {
+    ii=$2
+    interval=${3:-10}
+    while [ $ii -gt 0 ] ; do
+        $1 && break
+        sleep $interval
+        ii=`expr $ii - $interval`
+    done
+    if [ $ii -le 0 ] ; then
+        return 1
+    fi
+    return 0
+}
+
+# $1 - es hostname
+# $2 - project name (e.g. logging, test, .operations, etc.)
+# $3 - _count or _search
+# $4 - field to search
+# $5 - search string
+# $6 - extra params e.g. '&fields=message&size=1000'
+# stdout is the JSON output from Elasticsearch
+# stderr is curl errors
+curl_es() {
+    curl --connect-timeout 1 -s \
+       http://${1}:9200/${2}*/${3}\?q=${4}:"${5}""${6:-}"
+}
+
+get_count_from_json() {
+    python -c 'import json, sys; print json.loads(sys.stdin.read())["count"]'
+}
+
+# return true if the actual count matches the expected count, false otherwise
+# $1 - es hostname
+# $2 - project name (e.g. logging, test, .operations, etc.)
+# $3 - field to search
+# $4 - search string
+# $5 - expected count
+test_count_expected() {
+    myfield=${myfield:-message}
+    nrecs=`curl_es $1 $2 _count $3 $4 | get_count_from_json`
+    test "$nrecs" = $5
+}
+
+format_syslog_message() {
+    # $1 - full or short
+    # $2 - $NFMT
+    # $3 - $EXTRAFMT
+    # $4 - $prefix
+    # $5 - $ii
+    if [ "$1" = "full" ] ; then
+        printf "%s %s %s[%d]: %s-$2 $3\n" "$(date -u +'%b %d %H:%M:%S')" `hostname -s` \
+               $4 $$ $4 $5 1
+    else
+        printf "%s-$2 $3\n" $4 $5 1
+    fi
+}
+
+# get the date in utc Z format instead of regular -Ins format
+get_date() {
+    date -u +%FT%T.%NZ
+}
+
+format_json_message() {
+    # $1 - full or short
+    # $2 - $NFMT
+    # $3 - $EXTRAFMT
+    # $4 - $prefix
+    # $5 - $ii
+    msg=`printf "%s-$2 $3" $4 $5 1`
+    if [ "$1" = "full" ] ; then
+        printf '{"log":"%s\\n","stream":"stdout","time":"%s"}\n' "$msg" "`get_date`"
+    else
+        printf "%s\n" "$msg"
+    fi
+}
+
+get_journal_timestamp() {
+    # microseconds since epoch
+    date -u +%s%6N
+}
+
+# journal -o export format for use with
+# /usr/lib/systemd/systemd-journal-remote - -o /path/to/log.journal
+# __CURSOR=s=f689c3b9b8dc4465acd22433bde89aed;i=71f60;b=0937011437e44850b3cb5a615345b50f;m=d3bafda0f;t=5330b9fab5ca6;x=244e23370340b59b
+# _SOURCE_REALTIME_TIMESTAMP=1431439843797660
+# __REALTIME_TIMESTAMP=1463499900017830
+# __MONOTONIC_TIMESTAMP=56835955215
+# _BOOT_ID=0937011437e44850b3cb5a615345b50f
+# _UID=1000
+# _GID=1000
+# _CAP_EFFECTIVE=0
+# _SYSTEMD_OWNER_UID=1000
+# _SYSTEMD_SLICE=user-1000.slice
+# _MACHINE_ID=68fe516b647f4d0fb5b0439d57b79344
+# _HOSTNAME=localhost.localdomain
+# _TRANSPORT=stdout
+# PRIORITY=4
+# _AUDIT_SESSION=1
+# _AUDIT_LOGINUID=1000
+# _SYSTEMD_CGROUP=/user.slice/user-1000.slice/session-1.scope
+# _SYSTEMD_SESSION=1
+# _SYSTEMD_UNIT=session-1.scope
+# _SELINUX_CONTEXT=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
+# SYSLOG_FACILITY=3
+# CODE_FILE=../src/core/manager.c
+# CODE_LINE=1761
+# CODE_FUNCTION=process_event
+# SYSLOG_IDENTIFIER=firefox.desktop
+# _COMM=firefox
+# _EXE=/usr/lib64/firefox/firefox
+# _CMDLINE=/usr/lib64/firefox/firefox -new-instance -P default
+# MESSAGE=Failed to open VDPAU backend libvdpau_va_gl.so: cannot open shared object file: No such file or directory
+# _PID=2685
+format_journal_message() {
+    # $1 - full or short
+    # $2 - $NFMT
+    # $3 - $EXTRAFMT
+    # $4 - $prefix
+    # $5 - $ii
+    fac=1
+    sev=2
+    msg=`printf "%s-$2 $3" $4 $5 1`
+    ts=`get_journal_timestamp`
+    hn=`hostname -s`
+    if [ "$1" = "full" ] ; then
+        tee -a /tmp/junk <<EOF
+_SOURCE_REALTIME_TIMESTAMP=$ts
+__REALTIME_TIMESTAMP=$ts
+_BOOT_ID=0937011437e44850b3cb5a615345b50f
+_UID=1000
+_GID=1000
+_HOSTNAME=$hn
+SYSLOG_IDENTIFIER=$4
+SYSLOG_FACILITY=$fac
+_COMM=$4
+_PID=$$
+MESSAGE=$msg
+
+EOF
+    else
+        echo "$msg"
+    fi
+}
+
+# number of projects, number size, printf format
+NPROJECTS=${NPROJECTS:-10}
+NPSIZE=${NPSIZE:-2}
+NPFMT=${NPFMT:-"%0${NPSIZE}d"}
+
+podprefix="this-is-pod-"
+projprefix="this-is-project-"
+contprefix="this-is-container-"
+format_json_filename() {
+    # $1 - $ii
+    printf "%s${NPFMT}_%s${NPFMT}_%s${NPFMT}-%s.log\n" "$podprefix" $1 "$projprefix" $1 "$contprefix" $1 "`echo $1 | sha256sum | awk '{print $1}'`"
+}
+
+pushd ../docker-elasticsearch
+./build-image.sh
+popd
+
+DB_IN_CONTAINER=1 sh -x $testdir/../docker-elasticsearch/run-container.sh
+
+# make a bunch of container log file names in $datadir
+# name looks like this:
+# name-of-pod_name-of-project_container-name-64hexchars.log
+# contents are in JSON format like this:
+##
+# {"log":"here is where the actual output goes\n","stream":"stderr","time":"2016-04-26T17:09:37.759913885Z"}
+# {"log":"another message\n","stream":"stdout","time":"2016-04-26T17:09:38.759913885Z"}
+
+# number of messages per file
+NMESSAGES=${NMESSAGES:-10}
+# number size e.g. log base 10 of $NMESSAGES
+NSIZE=${NSIZE:-2}
+# printf format for message number
+NFMT=${NFMT:-"%0${NSIZE}d"}
+# size of each message - number of bytes to write to each line of the logger file, not
+# the actual size of the JSON that is stored into ES
+MSGSIZE=${MSGSIZE:-200}
+
+ii=1
+prefix=`uuidgen`
+# need $MSGSIZE - (36 + "-" + $NSIZE + " ") bytes
+n=`expr $MSGSIZE - 36 - 1 - $NSIZE - 1`
+EXTRAFMT=${EXTRAFMT:-"%0${n}d"}
+if [ "$USE_JOURNAL" = "true" ] ; then
+    formatter=format_journal_message
+    sysfilter() {
+        /usr/lib/systemd/systemd-journal-remote - -o $systemlog
+    }
+else
+    formatter=format_syslog_message
+    sysfilter() {
+        cat >> $systemlog
+    }
+fi
+while [ $ii -le $NMESSAGES ] ; do
+    # direct to /var/log/messages format
+    $formatter full "$NFMT" "$EXTRAFMT" "$prefix" "$ii" | sysfilter
+    $formatter short "$NFMT" "$EXTRAFMT" "$prefix" "$ii" >> $orig
+    jj=1
+    while [ $jj -le $NPROJECTS ] ; do
+        fn=`format_json_filename $jj`
+        format_json_message full "$NFMT" "$EXTRAFMT" "$prefix" "$ii" >> $datadir/docker/$fn
+        format_json_message short "$NFMT" "$EXTRAFMT" "$prefix" "$ii" >> $orig
+        jj=`expr $jj + 1`
+    done
+    ii=`expr $ii + 1`
+done
+
+if [ "$USE_FLUENTD" = "true" ] ; then
+    pushd ../docker-fluentd
+    ./build-image.sh
+    popd
+    # copy fluentd config to config dir
+    cp openshift-fluentd.conf $confdir/fluent.conf
+    cp $fluentd_syslog_input $confdir/syslog-input.conf
+    # run fluentd with the config dir mounted as /etc/fluentd
+    STARTTIME=$(date +%s)
+    collectorid=`docker run -p 5141:5141/udp -v $datadir:/datadir -v $confdir:/etc/fluent --link viaq-elasticsearch -e ES_HOST=viaq-elasticsearch -e OPS_HOST=viaq-elasticsearch -e ES_PORT=9200 -e OPS_PORT=9200 -e DATA_DIR=/datadir -e SYSLOG_LISTEN_PORT=5141 -d viaq/fluentd:latest`
+else
+    pushd ../docker-rsyslog-collector
+    ./build-image.sh
+    popd
+    pushd rsyslog-perf-test
+    cp $rsyslog_syslog_input syslog-input-filter.conf
+    ./build-image.sh
+    popd
+    # run rsyslog with the config dir mounted as /etc/rsyslog.d
+    STARTTIME=$(date +%s)
+    if [ "$USE_GDB" != false ] ; then
+        docker run -p 5141:5141/udp $rsyslog_bindmount -v $datadir:/datadir --link viaq-elasticsearch -e ES_HOST=viaq-elasticsearch -e SYSLOG_LISTEN_PORT=5141 -it viaq/rsyslog-perf-test:latest gdb --args /usr/sbin/rsyslogd -n
+    else
+        collectorid=`docker run -p 5141:5141/udp $rsyslog_bindmount -v $datadir:/datadir --link viaq-elasticsearch -e ES_HOST=viaq-elasticsearch -e SYSLOG_LISTEN_PORT=5141 -d viaq/rsyslog-perf-test:latest`
+    fi
+fi
+
+count_ge_nmessages() {
+    curcount=`curl_es $myhost $myproject _count $myfield "$mymessage" | get_count_from_json`
+    echo count $curcount time $(date +%s)
+    test $curcount -ge $NMESSAGES
+}
+
+echo waiting for $NMESSAGES messages in .operations and $NPROJECTS projects in elasticsearch
+
+myhost=localhost myproject=.operations myfield=ident mymessage=$prefix wait_until_cmd count_ge_nmessages 20 1 || {
+    echo error: $NMESSAGES messages not found in .operations
+    curl_es localhost .operations _search ident $prefix | python -mjson.tool
+    exit 1
+}
+
+ii=1
+while [ $ii -le $NPROJECTS ] ; do
+    myproject=`printf "%s${NPFMT}" $projprefix $ii`
+    myhost=localhost myproject=$myproject myfield=message mymessage=$prefix wait_until_cmd count_ge_nmessages 60 1 || {
+        echo error: $NMESSAGES messages not found in $myproject
+        curl_es localhost $myproject _search message $prefix | python -mjson.tool
+        exit 1
+    }
+done
+
+# now total number of records >= $startcount + $NMESSAGES
+# mark time
+MARKTIME=$(date +%s)
+
+echo duration `expr $MARKTIME - $STARTTIME`
+
+# search ES and extract the messages
+#esmessages=`mktemp`
+total=`expr $NMESSAGES \* \( $NPROJECTS + 1 \)`
+curl_es localhost "" _search message $prefix "&fields=message&size=$total" | \
+    python -c 'import json, sys; print "\n".join([ii["fields"]["message"][0] for ii in json.loads(sys.stdin.read())["hits"]["hits"]])' | \
+    grep -v '^$' | \
+    sort -n > $result
+
+sort -n $orig > $orig.sorted
+
+diff $orig.sorted $result

--- a/rsyslog-perf-test/Dockerfile
+++ b/rsyslog-perf-test/Dockerfile
@@ -1,0 +1,9 @@
+FROM viaq/rsyslog-collector:latest
+MAINTAINER The ViaQ Community <community@TBA>
+# for doing rsyslog performance tests
+ADD rsyslog.conf /etc/rsyslog.conf
+ADD *.rulebase syslog-input-filter.conf /etc/rsyslog.d/
+#ENV DEBUG=true RSYSLOG_DEBUG="Debug"
+RUN yum -y install gdb rsyslog-debuginfo
+
+CMD /usr/sbin/run.sh

--- a/rsyslog-perf-test/build-image.sh
+++ b/rsyslog-perf-test/build-image.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -ex
+prefix=${PREFIX:-${1:-viaq/}}
+version=${VERSION:-${2:-latest}}
+docker build --no-cache=false --pull=false -t "${prefix}rsyslog-perf-test:${version}" .
+
+if [ -n "${PUSH:-$3}" ]; then
+	docker push "${prefix}rsyslog-perf-test:${version}"
+fi

--- a/rsyslog-perf-test/k8s_filename.rulebase
+++ b/rsyslog-perf-test/k8s_filename.rulebase
@@ -1,0 +1,6 @@
+#rule=:-%container_id:string-to:.log%.log
+#rule=:%container_name_part:char-sep:-%%tail:rest%
+#rule=:/%paths:tokenized:/:char-sep:/%
+#rule=:/path/%kubernetes_pod_name:char-to:_%_%kubernetes_namespace_name:char-to:_%_%docker:tokenized:-:recursive%
+#rule=:/path/%kubernetes_pod_name:char-to:_%_%kubernetes_namespace_name:char-to:_%_%kubernetes_container_name_id:string-to:.log%.log
+rule=:/datadir/docker/%kubernetes_pod_name:char-to:_%_%kubernetes_namespace_name:char-to:_%_%container:tokenized:-:char-sep:-%

--- a/rsyslog-perf-test/rsyslog-input-file.conf
+++ b/rsyslog-perf-test/rsyslog-input-file.conf
@@ -1,0 +1,41 @@
+template(name="operations_index_pattern" type="list") {
+    constant(value=".operations.2016.")
+    property(name="$!time" dateFormat="rfc3339" position.from="1" position.to="3" caseConversion="lower")
+    constant(value=".")
+    property(name="$!time" dateFormat="rfc3339" position.from="5" position.to="6")
+    }
+
+template(name="operations_template" type="list") {
+    constant(value="{")
+    constant(value="\"time\":\"")               property(name="$!time")
+    constant(value="\",\"ident\":\"")           property(name="$!ident")
+    constant(value="\",\"pid\":\"")             property(name="$!pid")
+    constant(value="\",\"message\":\"")         property(name="$!message")
+    constant(value="\",\"hostname\":\"")        property(name="$!host")
+    constant(value="\",\"version\":\"1.1.4\"")
+    constant(value="}")
+}
+
+ruleset(name="system_logs") {
+#*.* :omstdout:;junk1
+    action(type="mmnormalize" ruleBase="/etc/rsyslog.d/var-log-messages.rulebase")
+#*.* :omstdout:RSYSLOG_DebugFormat
+
+#*.* :omstdout:;operations_index_pattern
+#*.* :omstdout:;operations_template
+    action(
+        type="omelasticsearch"
+        server="viaq-elasticsearch"
+        serverport="9200"
+        template="operations_template"
+        searchIndex="operations_index_pattern"
+        dynSearchIndex="on"
+        searchType="fluentd"
+        bulkmode="on"
+        queue.type="linkedlist"
+        queue.size="5000"
+        queue.dequeuebatchsize="600"
+        action.resumeretrycount="-1")
+}
+
+input(type="imfile" file="/datadir/messages*" tag="system" addmetadata="on" ruleset="system_logs")

--- a/rsyslog-perf-test/rsyslog-input-journal.conf
+++ b/rsyslog-perf-test/rsyslog-input-journal.conf
@@ -1,0 +1,48 @@
+module(load="imjournal" statefile="/datadir/imjournal.state" ratelimit.interval="600" ratelimit.burst="20000")
+
+template(name="operations_index_pattern" type="list") {
+    constant(value=".operations.")
+    property(name="TIMESTAMP" dateFormat="rfc3339" position.from="1" position.to="4")
+    constant(value=".")
+    property(name="TIMESTAMP" dateFormat="rfc3339" position.from="6" position.to="7")
+    constant(value=".")
+    property(name="TIMESTAMP" dateFormat="rfc3339" position.from="9" position.to="10")
+    }
+
+template(name="operations_template" type="list") {
+    constant(value="{")
+    constant(value="\"time\":\"")               property(name="TIMESTAMP" dateFormat="rfc3339")
+    constant(value="\",\"ident\":\"")           property(name="$.ident")
+    constant(value="\",\"pid\":\"")             property(name="$.pid")
+    constant(value="\",\"message\":\"")         property(name="msg" format="json")
+    constant(value="\",\"hostname\":\"")        property(name="$.hostname")
+    constant(value="\",\"version\":\"1.1.4\"")
+    constant(value="}")
+}
+
+:inputname, isequal, "imfile"  stop
+
+# these have to be lowercase to use in a property name="" above
+# except for TIMESTAMP and a few other fields which are "special" and can
+# be used uppercase
+set $.pid = $!_PID;
+set $.hostname = $!_HOSTNAME;
+set $.ident = $!SYSLOG_IDENTIFIER;
+
+#*.* :omstdout:;RSYSLOG_DebugFormat
+#*.* :omstdout:;operations_index_pattern
+#*.* :omstdout:;operations_template
+
+action(
+    type="omelasticsearch"
+    server="viaq-elasticsearch"
+    serverport="9200"
+    template="operations_template"
+    searchIndex="operations_index_pattern"
+    dynSearchIndex="on"
+    searchType="fluentd"
+    bulkmode="on"
+    queue.type="linkedlist"
+    queue.size="5000"
+    queue.dequeuebatchsize="600"
+    action.resumeretrycount="-1")

--- a/rsyslog-perf-test/rsyslog.conf
+++ b/rsyslog-perf-test/rsyslog.conf
@@ -1,0 +1,115 @@
+#$DebugLevel 2
+module(load="imfile")
+module(load="mmjsonparse")
+module(load="mmnormalize")
+# ElasticSearch output module
+module(load="omelasticsearch")
+module(load="omstdout")
+
+global(
+    # Where to place auxiliary files
+    workDirectory="/datadir"
+    # perf-dept: we want fully qualified domain names for common logging
+    preserveFQDN="on")
+
+template(name="kubernetes_template" type="list") {
+    constant(value="{")
+    constant(value="\"time\":\"")               property(name="$!time" dateFormat="rfc3339")
+    constant(value="\",\"kubernetes_namespace_name\":\"")           property(name="$!kubernetes_namespace_name")
+    constant(value="\",\"kubernetes_namespace_id\":\"")           property(name="$!kubernetes_namespace_id")
+    constant(value="\",\"docker_container_id\":\"")           property(name="$!docker_container_id")
+    constant(value="\",\"kubernetes_pod_name\":\"")           property(name="$!kubernetes_pod_name")
+    constant(value="\",\"kubernetes_host\":\"localhost") #           property(name="$!kubernetes_host")
+    constant(value="\",\"hostname\":\"")           property(name="$!hostname")
+    constant(value="\",\"message\":\"")           property(name="$!log" format="json")
+    constant(value="\",\"version\":\"1.1.4\"")
+    constant(value="}")
+}
+
+template(name="debug" type="list") {
+    constant(value="debugtemplate {\n")
+    constant(value="\tmsg=[") property(name="msg") constant(value="]\n")
+    constant(value="\trawmsg=[") property(name="rawmsg") constant(value="]\n")
+    constant(value="\trawmsg-after-pri=[") property(name="rawmsg-after-pri") constant(value="]\n")
+    constant(value="\thostname=[") property(name="hostname") constant(value="]\n")
+    constant(value="\tsource=[") property(name="source") constant(value="]\n")
+    constant(value="\tfromhost=[") property(name="fromhost") constant(value="]\n")
+    constant(value="\tfromhost-ip=[") property(name="fromhost-ip") constant(value="]\n")
+    constant(value="\tsyslogtag=[") property(name="syslogtag") constant(value="]\n")
+    constant(value="\tprogramname=[") property(name="programname") constant(value="]\n")
+    constant(value="\tpri=[") property(name="pri") constant(value="]\n")
+    constant(value="\tpri-text=[") property(name="pri-text") constant(value="]\n")
+    constant(value="\tiut=[") property(name="iut") constant(value="]\n")
+    constant(value="\tsyslogfacility=[") property(name="syslogfacility") constant(value="]\n")
+    constant(value="\tsyslogfacility-text=[") property(name="syslogfacility-text") constant(value="]\n")
+    constant(value="\tsyslogseverity=[") property(name="syslogseverity") constant(value="]\n")
+    constant(value="\tsyslogseverity-text=[") property(name="syslogseverity-text") constant(value="]\n")
+    constant(value="\tsyslogpriority=[") property(name="syslogpriority") constant(value="]\n")
+    constant(value="\tsyslogpriority-text=[") property(name="syslogpriority-text") constant(value="]\n")
+    constant(value="\ttimegenerated=[") property(name="timegenerated") constant(value="]\n")
+    constant(value="\ttimereported=[") property(name="timereported") constant(value="]\n")
+    constant(value="\ttimestamp=[") property(name="timestamp") constant(value="]\n")
+    constant(value="\tprotocol-version=[") property(name="protocol-version") constant(value="]\n")
+    constant(value="\tstructured-data=[") property(name="structured-data") constant(value="]\n")
+    constant(value="\tapp-name=[") property(name="app-name") constant(value="]\n")
+    constant(value="\tprocid=[") property(name="procid") constant(value="]\n")
+    constant(value="\tmsgid=[") property(name="msgid") constant(value="]\n")
+    constant(value="\tinputname=[") property(name="inputname") constant(value="]\n")
+    constant(value="}\n")
+}
+
+template(name="kubernetes_index_pattern" type="list") {
+    property(name="$!kubernetes_namespace_name")
+    constant(value=".")
+    property(name="$!kubernetes_namespace_id")
+    constant(value=".")
+    property(name="$!time" dateFormat="rfc3339" position.from="1" position.to="4")
+    constant(value=".")
+    property(name="$!time" dateFormat="rfc3339" position.from="6" position.to="7")
+    constant(value=".")
+    property(name="$!time" dateFormat="rfc3339" position.from="9" position.to="10")
+    }
+
+ruleset(name="kubernetes_logs") {
+    # parse as JSON
+    action(type="mmjsonparse" cookie="")
+    action(type="mmnormalize" variable="$!metadata!filename" ruleBase="/etc/rsyslog.d/k8s_filename.rulebase")
+    set $!kubernetes_container_name = "";
+    set $.delim = "";
+    foreach ($.ii in $!container) do {
+        # last field container_id ends with ".log"
+        set $.isend = field($.ii, 46, 2);
+        if (strlen($.isend) > 0) and ($.isend == 'log') then {
+            set $!docker_container_id = field($.ii, 46, 1);
+        } else {
+            # concat the other values together into the container name
+            reset $!kubernetes_container_name = $!kubernetes_container_name & $.delim & $.ii;
+            reset $.delim = "-";
+        }
+        unset $.isend;
+    }
+    unset $!container;
+    unset $.delim;
+    set $!kubernetes_namespace_id = "abcdefg";
+#*.* :omstdout:;RSYSLOG_DebugFormat
+#*.* :omstdout:;kubernetes_index_pattern
+#*.* :omstdout:;kubernetes_template
+    action(
+        type="omelasticsearch"
+        server="viaq-elasticsearch"
+        serverport="9200"
+        template="kubernetes_template"
+        searchIndex="kubernetes_index_pattern"
+        dynSearchIndex="on"
+        searchType="fluentd"
+        bulkmode="on"
+        queue.type="linkedlist"
+        queue.size="5000"
+        queue.dequeuebatchsize="600"
+        action.resumeretrycount="-1")
+    stop
+}
+
+input(type="imfile" file="/datadir/docker/*.log" tag="kubernetes" addmetadata="on" ruleset="kubernetes_logs")
+
+$IncludeConfig /etc/rsyslog.d/syslog-input-filter.conf

--- a/rsyslog-perf-test/rsyslog.conf.save
+++ b/rsyslog-perf-test/rsyslog.conf.save
@@ -1,0 +1,184 @@
+#$DebugLevel 2
+module(load="imfile")
+module(load="mmjsonparse")
+module(load="mmnormalize")
+# ElasticSearch output module
+module(load="omelasticsearch")
+module(load="omstdout")
+
+$DefaultParser "parser.pmrfc3164"
+
+global(
+    # Where to place auxiliary files
+    workDirectory="/datadir"
+    # perf-dept: we want fully qualified domain names for common logging
+    preserveFQDN="on")
+
+# Use default timestamp format
+#$ActionFileDefaultTemplate RSYSLOG_FileFormat
+
+template(name="operations_index_pattern" type="list") {
+    constant(value=".operations.")
+    property(name="$!time" dateFormat="rfc3339" position.from="1" position.to="4")
+    constant(value=".")
+    property(name="$!time" dateFormat="rfc3339" position.from="6" position.to="7")
+    constant(value=".")
+    property(name="$!time" dateFormat="rfc3339" position.from="9" position.to="10")
+    }
+
+template(name="operations_template" type="list") {
+    constant(value="{")
+    constant(value="\"time\":\"")               property(name="$!time" dateFormat="rfc3339")
+    constant(value="\",\"ident\":\"")           property(name="$!ident")
+    constant(value="\",\"pid\":\"")             property(name="$!pid")
+    constant(value="\",\"message\":\"")         property(name="$!message")
+    constant(value="\",\"hostname\":\"")        property(name="$!host")
+    constant(value="\",\"version\":\"1.1.4\"")
+    constant(value="}")
+}
+
+template(name="kubernetes_template" type="list") {
+    constant(value="{")
+    constant(value="\"time\":\"")               property(name="$!time" dateFormat="rfc3339")
+    constant(value="\",\"kubernetes_namespace_name\":\"")           property(name="$!kubernetes_namespace_name")
+    constant(value="\",\"kubernetes_namespace_id\":\"")           property(name="$!kubernetes_namespace_id")
+    constant(value="\",\"docker_container_id\":\"")           property(name="$!docker_container_id")
+    constant(value="\",\"kubernetes_pod_name\":\"")           property(name="$!kubernetes_pod_name")
+    constant(value="\",\"kubernetes_host\":\"localhost") #           property(name="$!kubernetes_host")
+    constant(value="\",\"hostname\":\"")           property(name="$!hostname")
+    constant(value="\",\"message\":\"")           property(name="$!log")
+    constant(value="\",\"version\":\"1.1.4\"")
+    constant(value="}")
+}
+
+template(name="debug" type="list") {
+    constant(value="debugtemplate {\n")
+    constant(value="\tmsg=[") property(name="msg") constant(value="]\n")
+    constant(value="\trawmsg=[") property(name="rawmsg") constant(value="]\n")
+    constant(value="\trawmsg-after-pri=[") property(name="rawmsg-after-pri") constant(value="]\n")
+    constant(value="\thostname=[") property(name="hostname") constant(value="]\n")
+    constant(value="\tsource=[") property(name="source") constant(value="]\n")
+    constant(value="\tfromhost=[") property(name="fromhost") constant(value="]\n")
+    constant(value="\tfromhost-ip=[") property(name="fromhost-ip") constant(value="]\n")
+    constant(value="\tsyslogtag=[") property(name="syslogtag") constant(value="]\n")
+    constant(value="\tprogramname=[") property(name="programname") constant(value="]\n")
+    constant(value="\tpri=[") property(name="pri") constant(value="]\n")
+    constant(value="\tpri-text=[") property(name="pri-text") constant(value="]\n")
+    constant(value="\tiut=[") property(name="iut") constant(value="]\n")
+    constant(value="\tsyslogfacility=[") property(name="syslogfacility") constant(value="]\n")
+    constant(value="\tsyslogfacility-text=[") property(name="syslogfacility-text") constant(value="]\n")
+    constant(value="\tsyslogseverity=[") property(name="syslogseverity") constant(value="]\n")
+    constant(value="\tsyslogseverity-text=[") property(name="syslogseverity-text") constant(value="]\n")
+    constant(value="\tsyslogpriority=[") property(name="syslogpriority") constant(value="]\n")
+    constant(value="\tsyslogpriority-text=[") property(name="syslogpriority-text") constant(value="]\n")
+    constant(value="\ttimegenerated=[") property(name="timegenerated") constant(value="]\n")
+    constant(value="\ttimereported=[") property(name="timereported") constant(value="]\n")
+    constant(value="\ttimestamp=[") property(name="timestamp") constant(value="]\n")
+    constant(value="\tprotocol-version=[") property(name="protocol-version") constant(value="]\n")
+    constant(value="\tstructured-data=[") property(name="structured-data") constant(value="]\n")
+    constant(value="\tapp-name=[") property(name="app-name") constant(value="]\n")
+    constant(value="\tprocid=[") property(name="procid") constant(value="]\n")
+    constant(value="\tmsgid=[") property(name="msgid") constant(value="]\n")
+    constant(value="\tinputname=[") property(name="inputname") constant(value="]\n")
+    constant(value="}\n")
+}
+
+template(name="kubernetes_index_pattern" type="list") {
+    property(name="$!kubernetes_namespace_name")
+    constant(value=".")
+    property(name="$!kubernetes_namespace_id")
+    constant(value=".")
+    property(name="$!time" dateFormat="rfc3339" position.from="1" position.to="4")
+    constant(value=".")
+    property(name="$!time" dateFormat="rfc3339" position.from="6" position.to="7")
+    constant(value=".")
+    property(name="$!time" dateFormat="rfc3339" position.from="9" position.to="10")
+    }
+
+parser(name="custom.rfc3164" type="pmrfc3164"
+       permit.squareBracketsInHostname="on"
+       detect.YearAfterTimestamp="on")
+
+ruleset(name="system_logs") {
+#*.* :omstdout:;junk1
+*.* :omstdout:
+*.* :omstdout:;operations_index_pattern
+*.* :omstdout:;operations_template
+#    action(type="mmnormalize" ruleBase="/etc/rsyslog.d/var-log-messages.rulebase")
+
+*.* :omstdout:;operations_index_pattern
+*.* :omstdout:;operations_template
+    action(
+        type="omelasticsearch"
+        server="viaq-elasticsearch"
+        serverport="9200"
+        template="operations_template"
+        searchIndex="operations_index_pattern"
+        dynSearchIndex="on"
+        searchType="fluentd"
+        bulkmode="on"
+        queue.type="linkedlist"
+        queue.size="5000"
+        queue.dequeuebatchsize="600"
+        action.resumeretrycount="-1")
+}
+
+template(name="junk1" type="list") { constant(value="<133>") property(name="msg") }
+template(name="junk2" type="list") { constant(value="<133>") property(name="rawmsg") }
+
+#ruleset(name="system_logs_rfc3164") {
+ruleset(name="system_logs_rfc3164" parser="custom.rfc3164") {
+#     reset $msg = exec_template("junk1");
+#     reset $rawmsg = exec_template("junk2");
+#*.* :omstdout:;RSYSLOG_DebugFormat
+#*.* :omstdout:;debug
+# $/msg is not the same as system property msg
+#     reset $/msg = exec_template("junk1");
+# $msg is not found 
+#     reset $msg = exec_template("junk1");
+# this just barfs
+#     reset msg = exec_template("junk1");
+#*.* :omstdout:;RSYSLOG_DebugFormat
+#*.* :omstdout:;debug
+    call system_logs
+}
+
+ruleset(name="kubernetes_logs") {
+    # parse as JSON
+    action(type="mmjsonparse" cookie="")
+    action(type="mmnormalize" variable="$!metadata!filename" ruleBase="/etc/rsyslog.d/k8s_filename.rulebase")
+    set $!kubernetes_container_name = "";
+    set $.delim = "";
+    foreach ($.ii in $!container) do {
+        # last field container_id ends with ".log"
+        set $.isend = field($.ii, 46, 2);
+        if (strlen($.isend) > 0) and ($.isend == 'log') then {
+            set $!docker_container_id = field($.ii, 46, 1);
+        } else {
+            # concat the other values together into the container name
+            reset $!kubernetes_container_name = $!kubernetes_container_name & $.delim & $.ii;
+            reset $.delim = "-";
+        }
+        unset $.isend;
+    }
+    unset $!container;
+    unset $.delim;
+*.* :omstdout:;kubernetes_index_pattern
+*.* :omstdout:;kubernetes_template
+    # action(
+    #     type="omelasticsearch"
+    #     server="127.0.0.1"
+    #     serverport="9200"
+    #     template="kubernetes_template"
+    #     searchIndex="kubernetes_index_pattern"
+    #     dynSearchIndex="on"
+    #     searchType="fluentd"
+    #     bulkmode="on"
+    #     queue.type="linkedlist"
+    #     queue.size="5000"
+    #     queue.dequeuebatchsize="600"
+    #     action.resumeretrycount="-1")
+}
+
+#input(type="imfile" file="/datadir/docker/*.log" tag="kubernetes" addmetadata="on" ruleset="kubernetes_logs")
+input(type="imfile" file="/datadir/messages*" tag="system" addmetadata="on" ruleset="system_logs_rfc3164" parser="custom.rfc3164")

--- a/rsyslog-perf-test/syslog-input-filter.conf
+++ b/rsyslog-perf-test/syslog-input-filter.conf
@@ -1,0 +1,48 @@
+module(load="imjournal" statefile="/datadir/imjournal.state" ratelimit.interval="600" ratelimit.burst="20000")
+
+template(name="operations_index_pattern" type="list") {
+    constant(value=".operations.")
+    property(name="TIMESTAMP" dateFormat="rfc3339" position.from="1" position.to="4")
+    constant(value=".")
+    property(name="TIMESTAMP" dateFormat="rfc3339" position.from="6" position.to="7")
+    constant(value=".")
+    property(name="TIMESTAMP" dateFormat="rfc3339" position.from="9" position.to="10")
+    }
+
+template(name="operations_template" type="list") {
+    constant(value="{")
+    constant(value="\"time\":\"")               property(name="TIMESTAMP" dateFormat="rfc3339")
+    constant(value="\",\"ident\":\"")           property(name="$.ident")
+    constant(value="\",\"pid\":\"")             property(name="$.pid")
+    constant(value="\",\"message\":\"")         property(name="msg" format="json")
+    constant(value="\",\"hostname\":\"")        property(name="$.hostname")
+    constant(value="\",\"version\":\"1.1.4\"")
+    constant(value="}")
+}
+
+:inputname, isequal, "imfile"  stop
+
+# these have to be lowercase to use in a property name="" above
+# except for TIMESTAMP and a few other fields which are "special" and can
+# be used uppercase
+set $.pid = $!_PID;
+set $.hostname = $!_HOSTNAME;
+set $.ident = $!SYSLOG_IDENTIFIER;
+
+#*.* :omstdout:;RSYSLOG_DebugFormat
+#*.* :omstdout:;operations_index_pattern
+#*.* :omstdout:;operations_template
+
+action(
+    type="omelasticsearch"
+    server="viaq-elasticsearch"
+    serverport="9200"
+    template="operations_template"
+    searchIndex="operations_index_pattern"
+    dynSearchIndex="on"
+    searchType="fluentd"
+    bulkmode="on"
+    queue.type="linkedlist"
+    queue.size="5000"
+    queue.dequeuebatchsize="600"
+    action.resumeretrycount="-1")

--- a/rsyslog-perf-test/var-log-messages.rulebase
+++ b/rsyslog-perf-test/var-log-messages.rulebase
@@ -1,0 +1,3 @@
+prefix=%time:date-rfc3164% %host:word%
+rule=: %ident:char-to:[%[%pid:number%]: %message:rest%
+rule=: %ident:char-to:\x3a%: %message:rest%


### PR DESCRIPTION
…iner

Run openshift-test.sh with USE_FLUENTD=true to test fluentd, use
USE_FLUENTD=false to test rsyslog.
USE_JOURNAL=true will use journal input to log collector for the system
logs, otherwise, read from /var/log/messages style files.
Because rsyslog-collector docker container configuration is not as flexible
as fluentd container, we build a special rsyslog-perf-test container with
our specific configuration, layered on top of the rsyslog-collector.
