### PR TITLE
Add monitor agent source

### DIFF
--- a/openshift-fluentd.conf
+++ b/openshift-fluentd.conf
@@ -2,6 +2,12 @@
   log_level warn
 </system>
 
+<source>
+  @type monitor_agent
+  bind "0.0.0.0"
+  port "24220"
+</source>
+
 @include syslog-input.conf
 
 <source>


### PR DESCRIPTION
We need to add `<source>` definition for monitor agent if we want to use it in tests.
