### PR TITLE
Fix broken loop statement

### DIFF
--- a/openshift-test.sh
+++ b/openshift-test.sh
@@ -318,14 +318,15 @@ myhost=localhost myproject=.operations myfield=ident mymessage=$prefix wait_unti
     exit 1
 }
 
-ii=1
-while [ $ii -le $NPROJECTS ] ; do
-    myproject=`printf "%s${NPFMT}" $projprefix $ii`
+iii=1
+while [ $iii -le $NPROJECTS ] ; do
+    myproject=`printf "%s${NPFMT}" $projprefix $iii`
     myhost=localhost myproject=$myproject myfield=message mymessage=$prefix wait_until_cmd count_ge_nmessages 60 1 || {
         echo error: $NMESSAGES messages not found in $myproject
         curl_es localhost $myproject _search message $prefix | python -mjson.tool
         exit 1
     }
+    iii=`expr $iii + 1`
 done
 
 # now total number of records >= $startcount + $NMESSAGES


### PR DESCRIPTION
We had a bug in testing script. The variable `ii` is already used in different places and setting it here to `1` and reusing it in general was an issue. It caused the test to test expected number of records only for the first project index and skipping all the other project indices.
