### PR TITLE
Elasticsearch 2.4.4 support; bulk ops timeout; journal-maker

### DIFF
--- a/journal-container-run.sh
+++ b/journal-container-run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -euo pipefail
+
+sjr=/usr/lib/systemd/systemd-journal-remote
+yum install -y $sjr > /dev/null
+cat $INPUTFILE | $sjr - -o $OUTPUTFILE
+chmod 777 `dirname $OUTPUTFILE`
+chmod 644 $OUTPUTFILE
+journalctl --file $OUTPUTFILE -n 1

--- a/journal-maker/Dockerfile
+++ b/journal-maker/Dockerfile
@@ -1,0 +1,11 @@
+FROM centos:7
+
+MAINTAINER The ViaQ Community <community@TBA>
+
+ENV INPUTFILE=/var/log/journalinput.txt \
+    OUTPUTFILE=/var/log/journal/messages.journal
+
+RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+    yum -y install /usr/lib/systemd/systemd-journal-remote
+
+CMD /usr/lib/systemd/systemd-journal-remote -o ${OUTPUTFILE} ${INPUTFILE}

--- a/openshift-fluentd-syslog-journal.conf
+++ b/openshift-fluentd-syslog-journal.conf
@@ -1,7 +1,8 @@
 <source>
   @type systemd
-  path "#{ENV['DATA_DIR']}/journal"
-  pos_file "#{ENV['DATA_DIR']}/journal.pos"
-  tag system.journal
-  read_from_head true
+  @label @INGRESS
+  path "#{ENV['JOURNAL_SOURCE'] || '/run/log/journal'}"
+  pos_file /var/log/journal.pos
+  tag journal
+  read_from_head "#{ENV['JOURNAL_READ_FROM_HEAD'] || 'false'}"
 </source>

--- a/openshift-fluentd/configs.d/openshift/es-copy-config.conf
+++ b/openshift-fluentd/configs.d/openshift/es-copy-config.conf
@@ -3,7 +3,7 @@
       host "#{ENV['ES_COPY_HOST']}"
       port "#{ENV['ES_COPY_PORT']}"
       scheme "#{ENV['ES_COPY_SCHEME']}"
-      index_name ${record['kubernetes_namespace_name']}.${record['kubernetes_namespace_id']}.${Time.at(time).getutc.strftime(@logstash_dateformat)}
+      index_name project.${record['kubernetes']['namespace_name']}.${record['kubernetes']['namespace_id']}.${Time.parse(record['@timestamp']).getutc.strftime(@logstash_dateformat)}
       user "#{ENV['ES_COPY_USERNAME']}"
       password "#{ENV['ES_COPY_PASSWORD']}"
 
@@ -11,6 +11,12 @@
       client_cert "#{ENV['ES_COPY_CLIENT_CERT']}"
       ca_file "#{ENV['ES_COPY_CA']}"
 
+      type_name com.redhat.viaq.common
+
+      # there is currently a bug in the es plugin + excon - cannot
+      # recreate/reload connections
+      reload_connections false
+      reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit

--- a/openshift-fluentd/configs.d/openshift/es-ops-copy-config.conf
+++ b/openshift-fluentd/configs.d/openshift/es-ops-copy-config.conf
@@ -3,7 +3,7 @@
       host "#{ENV['OPS_COPY_HOST']}"
       port "#{ENV['OPS_COPY_PORT']}"
       scheme "#{ENV['OPS_COPY_SCHEME']}"
-      index_name .operations.${record['time'].nil? ? Time.at(time).getutc.strftime(@logstash_dateformat) : Time.parse(record['time']).getutc.strftime(@logstash_dateformat)}
+      index_name .operations.${record['@timestamp'].nil? ? Time.at(time).getutc.strftime(@logstash_dateformat) : Time.parse(record['@timestamp']).getutc.strftime(@logstash_dateformat)}
       user "#{ENV['OPS_COPY_USERNAME']}"
       password "#{ENV['OPS_COPY_PASSWORD']}"
 
@@ -11,6 +11,12 @@
       client_cert "#{ENV['OPS_COPY_CLIENT_CERT']}"
       ca_file "#{ENV['OPS_COPY_CA']}"
 
+      type_name com.redhat.viaq.common
+
+      # there is currently a bug in the es plugin + excon - cannot
+      # recreate/reload connections
+      reload_connections false
+      reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit

--- a/openshift-fluentd/configs.d/openshift/filter-k8s-record-transform.conf
+++ b/openshift-fluentd/configs.d/openshift/filter-k8s-record-transform.conf
@@ -1,30 +1,34 @@
 <filter kubernetes.journal.container**>
-  type record_transformer
+  @type record_transformer
   enable_ruby
   <record>
+    # FixMe
+    # Top level hostname field; it comes from record['HOSTNAME']
+    # The index mapping has a field record['kubernetes']['hostname'];
+    # it comes from record['kubernetes']['host'] or File.open('/etc/docker-hostname')
+    # Needs to set a field inside a hash.
+    # Plus we'd better avoid the file IO.
     hostname ${(record['kubernetes']['host'] rescue nil) || File.open('/etc/docker-hostname') { |f| f.readline }.rstrip}
     # log is set if MESSAGE is JSON valued and has err or msg field
     message ${record['MESSAGE'] || log}
-    version 1.3.0
-    time ${Time.at((record["_SOURCE_REALTIME_TIMESTAMP"] || record["__REALTIME_TIMESTAMP"]).to_f / 1000000.0).to_datetime.rfc3339(6)}
+    level ${record['PRIORITY']}
+    time ${Time.at((record["_SOURCE_REALTIME_TIMESTAMP"] || record["__REALTIME_TIMESTAMP"]).to_f / 1000000.0).utc.to_datetime.rfc3339(6)}
+    pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-systemd","name":"fluentd openshift","received_at":"${Time.at((record['_SOURCE_REALTIME_TIMESTAMP'] || record['__REALTIME_TIMESTAMP']).to_f / 1000000.0).utc.to_datetime.rfc3339(6)}","version":"0.12.29 1.4.0"}}
   </record>
-  # revisit this list when we can handle all of the other journal metadata
   # we have to use remove_keys - we can't use renew_record + keep_keys because the
   # k8s meta plugin adds the labels with dynamic names, and we can't keep_keys with wildcards/patterns
-  remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID
+  remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
 </filter>
 
-# <filter **logme>
-#   @type stdout
-# </filter>
-
 <filter kubernetes.var.log.containers**>
-  type record_transformer
+  @type record_transformer
   enable_ruby
   <record>
     hostname ${(record['kubernetes']['host'] rescue nil) || File.open('/etc/docker-hostname') { |f| f.readline }.rstrip}
     message ${(message rescue nil) || log}
-    version 1.3.0
+    pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-in_tail","name":"fluentd openshift","received_at":"${record['time'].to_s}","version":"0.12.29 1.4.0"}}
+    level ${record['stream'] == 'stdout' ? 6 : 3}
+    time ${time.utc.to_datetime.rfc3339(6)}
   </record>
   remove_keys log,stream
 </filter>

--- a/openshift-fluentd/configs.d/openshift/filter-kibana-transform.conf
+++ b/openshift-fluentd/configs.d/openshift/filter-kibana-transform.conf
@@ -1,5 +1,5 @@
 <filter **kibana**>
-  type record_transformer
+  @type record_transformer
   enable_ruby
   <record>
     log ${(err rescue nil) || (msg rescue nil) || record['MESSAGE'] || log}

--- a/openshift-fluentd/configs.d/openshift/filter-syslog-record-transform.conf
+++ b/openshift-fluentd/configs.d/openshift/filter-syslog-record-transform.conf
@@ -1,7 +1,8 @@
 <filter system.var.log**>
-  type record_transformer
+  @type record_transformer
   enable_ruby
   <record>
+    systemd {"t":{"PID":"${record['pid']}"},"u":{"SYSLOG_IDENTIFIER":"${record['ident']}"}}
     # if host == 'localhost' do a fqdn lookup
     ## we pull the hostname from the host's /etc/hostname mounted at /etc/docker-hostname to correctly identify the hostname
     hostname ${host.eql?('localhost') ? (begin; File.open('/etc/docker-hostname') { |f| f.readline }.rstrip; rescue; host; end) : host}
@@ -9,29 +10,37 @@
     # we want to correct the time here in cases where we are reading logs from a prior year.  By default Ruby will assume the current date for
     # parsing, and since syslog messages do not include the year, it will populate the year with the current year which may resolve to a future date
     # if the resolved date is in the future, we will subtract 1 from the year and use that
-    time ${ (Time.at(time) > Time.now) ? (Time.new((time.year - 1), time.month, time.day, time.hour, time.min, time.sec, time.utc_offset).to_datetime.to_s) : (time.to_datetime.to_s) }
+    time ${ (Time.at(time) > Time.now) ? (Time.new((time.year - 1), time.month, time.day, time.hour, time.min, time.sec, time.utc_offset).utc.to_datetime.rfc3339(6)) : (time.utc.to_datetime.rfc3339(6)) }
 
 
     #tag ${tag}_.operations_log
-    version 1.3.0
+    pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-in_tail","name":"fluentd openshift","received_at":"${(Time.at(time) > Time.now) ? (Time.new((time.year - 1), time.month, time.day, time.hour, time.min, time.sec, time.utc_offset).utc.to_datetime.rfc3339(6)) : (time.utc.to_datetime.rfc3339(6))}","version":"0.12.29 1.4.0"}}
   </record>
-  remove_keys host
+  remove_keys host,pid,ident
 </filter>
 
 <filter journal.system**>
-  type record_transformer
+  @type record_transformer
   enable_ruby
   # keep only the fields set explicitly below - remove to see all journal fields
-  renew_record
+  # correction: we need to keep the extra input under "undefined" field.
+  # can't use renew_record because we need to preserve existing undefined fields
   <record>
+    systemd {"t":{"MACHINE_ID":"${record['_MACHINE_ID']}","AUDIT_LOGINUID":"${record['_AUDIT_LOGINUID']}","AUDIT_SESSION":"${record['_AUDIT_SESSION']}","BOOT_ID":"${record['_BOOT_ID']}","CAP_EFFECTIVE":"${record['_CAP_EFFECTIVE']}","CMDLINE":"${record['_CMDLINE']}","COMM":"${record['_COMM']}","EXE":"${record['_EXE']}","GID":"${record['_GID']}","HOSTNAME":"${record['_HOSTNAME']}","PID":"${record['_PID']}","SELINUX_CONTEXT":"${record['_SELINUX_CONTEXT']}","SOURCE_REALTIME_TIMESTAMP":"${record['_SOURCE_REALTIME_TIMESTAMP']}","SYSTEMD_CGROUP":"${record['_SYSTEMD_CGROUP']}","SYSTEMD_OWNER_UID":"${record['_SYSTEMD_OWNER_UID']}","SYSTEMD_SESSION":"${record['_SYSTEMD_SESSION']}","SYSTEMD_SLICE":"${record['_SYSTEMD_SLICE']}","SYSTEMD_UNIT":"${record['_SYSTEMD_UNIT']}","SYSTEMD_USER_UNIT":"${record['_SYSTEMD_USER_UNIT']}","TRANSPORT":"${record['_TRANSPORT']}","UID":"${record['_UID']}"},"u":{"CODE_FILE":"${record['CODE_FILE']}","CODE_FUNCTION":"${record['CODE_FUNCTION']}","CODE_LINE":"${record['CODE_LINE']}","ERRNO":"${record['ERRNO']}","MESSAGE_ID":"${record['MESSAGE_ID']}","RESULT":"${record['RESULT']}","UNIT":"${record['UNIT']}","SYSLOG_FACILITY":"${record['SYSLOG_FACILITY']}","SYSLOG_IDENTIFIER":"${record['SYSLOG_IDENTIFIER']}","SYSLOG_PID":"${record['SYSLOG_PID']}"},"k":{"KERNEL_DEVICE":"${record['_KERNEL_DEVICE']}","KERNEL_SUBSYSTEM":"${record['_KERNEL_SUBSYSTEM']}","UDEV_SYSNAME":"${record['_UDEV_SYSNAME']}","UDEV_DEVNODE":"${record['_UDEV_DEVNODE']}","UDEV_DEVLINK":"${record['_UDEV_DEVLINK']}"}}
     # if host == 'localhost' do a fqdn lookup
     ## we pull the hostname from the host's /etc/hostname mounted at /etc/docker-hostname to correctly identify the hostname
+    # FixMe
+    # Top level hostname field; it comes from record['HOSTNAME']
+    # The index mapping has a field record['kubernetes']['hostname'];
+    # it comes from record['kubernetes']['host'] or File.open('/etc/docker-hostname')
+    # Needs to set a field inside a hash.
+    # Plus we'd better avoid the file IO.
     hostname ${_HOSTNAME.eql?('localhost') ? (begin; File.open('/etc/docker-hostname') { |f| f.readline }.rstrip; rescue; _HOSTNAME; end) : _HOSTNAME}
-    # if the field name begins with an uppercase letter, or might not exist, you have to use the record["FIELDNAME"] style
-    time ${(record["_SOURCE_REALTIME_TIMESTAMP"] || record["__REALTIME_TIMESTAMP"]) ? Time.at((record["_SOURCE_REALTIME_TIMESTAMP"] || record["__REALTIME_TIMESTAMP"]).to_f / 1000000.0).to_datetime.rfc3339(6) : time}
-    # if field is optional you have to use record[name] or (name rescue nil) or something like that
-    ident ${record["SYSLOG_IDENTIFIER"] || record["_COMM"]}
     message ${record["MESSAGE"]}
-    version 1.3.0
+    pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-systemd","name":"fluentd openshift","received_at":"${(record['_SOURCE_REALTIME_TIMESTAMP'] || record['__REALTIME_TIMESTAMP']) ? Time.at((record['_SOURCE_REALTIME_TIMESTAMP'] || record['__REALTIME_TIMESTAMP']).to_f / 1000000.0).utc.to_datetime.rfc3339(6) : time.utc.to_datetime.rfc3339(6)}","version":"0.12.29 1.4.0"}}
+    # if the field name begins with an uppercase letter, or might not exist, you have to use the record["FIELDNAME"] style
+    time ${(record["_SOURCE_REALTIME_TIMESTAMP"] || record["__REALTIME_TIMESTAMP"]) ? Time.at((record["_SOURCE_REALTIME_TIMESTAMP"] || record["__REALTIME_TIMESTAMP"]).to_f / 1000000.0).utc.to_datetime.rfc3339(6) : time.utc.to_datetime.rfc3339(6)}
+    # if field is optional you have to use record[name] or (name rescue nil) or something like that
   </record>
+  remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
 </filter>

--- a/openshift-fluentd/configs.d/openshift/filter-viaq-data-model.conf
+++ b/openshift-fluentd/configs.d/openshift/filter-viaq-data-model.conf
@@ -1,0 +1,12 @@
+<filter **>
+  @type viaq_data_model
+  default_keep_fields CEE,docker,file,geoip,hostname,kubernetes,level,message,offset,pid,pipeline_metadata,rsyslog,service,systemd,tags,time
+  extra_keep_fields "#{ENV['CDM_EXTRA_KEEP_FIELDS'] || ''}"
+  keep_empty_fields "#{ENV['CDM_KEEP_EMPTY_FIELDS'] || 'message'}"
+  use_undefined "#{ENV['CDM_USE_UNDEFINED'] || false}"
+  undefined_name "#{ENV['CDM_UNDEFINED_NAME'] || 'undefined'}"
+  rename_time "#{ENV['CDM_RENAME_TIME'] || true}"
+  rename_time_if_missing "#{ENV['CDM_RENAME_TIME_IF_MISSING'] || false}"
+  src_time_name "#{ENV['CDM_SRC_TIME_NAME'] || 'time'}"
+  dest_time_name "#{ENV['CDM_DEST_TIME_NAME'] || '@timestamp'}"
+</filter>

--- a/openshift-fluentd/configs.d/openshift/output-applications.conf
+++ b/openshift-fluentd/configs.d/openshift/output-applications.conf
@@ -3,4 +3,5 @@
    @include output-es-config.conf
    @include ../user/output-extra-*.conf
    @include ../dynamic/es-copy-config.conf
+   @include ../user/secure-forward.conf
 </match>

--- a/openshift-fluentd/configs.d/openshift/output-es-config.conf
+++ b/openshift-fluentd/configs.d/openshift/output-es-config.conf
@@ -2,8 +2,8 @@
       @type elasticsearch_dynamic
       host "#{ENV['ES_HOST']}"
       port "#{ENV['ES_PORT']}"
-      scheme http
-      index_name ${record['kubernetes']['namespace_name']}.${record['kubernetes']['namespace_id']}.${Time.at(time).getutc.strftime(@logstash_dateformat)}
+      scheme "#{ENV['ES_SCHEME'] || 'https'}"
+      index_name project.${record['kubernetes']['namespace_name']}.${record['kubernetes']['namespace_id']}.${Time.parse(record['@timestamp']).getutc.strftime(@logstash_dateformat)}
       user fluentd
       password changeme
 
@@ -11,7 +11,14 @@
       client_cert "#{ENV['ES_CLIENT_CERT']}"
       ca_file "#{ENV['ES_CA']}"
 
+      type_name com.redhat.viaq.common
+
+      # there is currently a bug in the es plugin + excon - cannot
+      # recreate/reload connections
+      reload_connections false
+      reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit
+      request_timeout 15s
     </store>

--- a/openshift-fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/openshift-fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -2,8 +2,8 @@
       @type elasticsearch_dynamic
       host "#{ENV['OPS_HOST']}"
       port "#{ENV['OPS_PORT']}"
-      scheme http
-      index_name .operations.${record['time'].nil? ? Time.at(time).getutc.strftime(@logstash_dateformat) : Time.parse(record['time']).getutc.strftime(@logstash_dateformat)}
+      scheme "#{ENV['OPS_SCHEME'] || 'https'}"
+      index_name .operations.${record['@timestamp'].nil? ? Time.at(time).getutc.strftime(@logstash_dateformat) : Time.parse(record['@timestamp']).getutc.strftime(@logstash_dateformat)}
       user fluentd
       password changeme
 
@@ -11,7 +11,14 @@
       client_cert "#{ENV['OPS_CLIENT_CERT']}"
       ca_file "#{ENV['OPS_CA']}"
 
+      type_name com.redhat.viaq.common
+
+      # there is currently a bug in the es plugin + excon - cannot
+      # recreate/reload connections
+      reload_connections false
+      reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit
+      request_timeout 15s
     </store>

--- a/openshift-fluentd/configs.d/openshift/output-operations.conf
+++ b/openshift-fluentd/configs.d/openshift/output-operations.conf
@@ -3,4 +3,5 @@
   @include output-es-ops-config.conf
   @include ../user/output-ops-extra-*.conf
   @include ../dynamic/es-ops-copy-config.conf
+  @include ../user/secure-forward.conf
 </match>

--- a/openshift-fluentd/configs.d/user/fluent.conf
+++ b/openshift-fluentd/configs.d/user/fluent.conf
@@ -20,9 +20,9 @@
   @include configs.d/openshift/filter-retag-journal.conf
   @include configs.d/openshift/filter-k8s-meta.conf
   @include configs.d/openshift/filter-kibana-transform.conf
-  @include configs.d/openshift/filter-k8s-flatten-hash.conf
   @include configs.d/openshift/filter-k8s-record-transform.conf
   @include configs.d/openshift/filter-syslog-record-transform.conf
+  @include configs.d/openshift/filter-viaq-data-model.conf
   @include configs.d/openshift/filter-post-*.conf
 ##
 

--- a/openshift-fluentd/fluent.conf
+++ b/openshift-fluentd/fluent.conf
@@ -23,6 +23,7 @@
   @include configs.d/openshift/filter-k8s-flatten-hash.conf
   @include configs.d/openshift/filter-k8s-record-transform.conf
   @include configs.d/openshift/filter-syslog-record-transform.conf
+  @include configs.d/openshift/filter-viaq-data-model.conf
   @include configs.d/openshift/filter-post-*.conf
 ##
 

--- a/openshift-test.sh
+++ b/openshift-test.sh
@@ -8,16 +8,26 @@ pushd $testdir
 USE_FLUENTD=${USE_FLUENTD:-true}
 USE_GDB=${USE_GDB:-false}
 USE_JOURNAL=${USE_JOURNAL:-true}
+ES_VER=${ES_VER:-2.4.4}
+DEBUG_FLUENTD=false
 # by default, if we're using journal, we will use it for both system messages
 # and container messages
 USE_JOURNAL_FOR_CONTAINERS=${USE_JOURNAL_FOR_CONTAINERS:-$USE_JOURNAL}
+# so, something broke somewhere about using systemd-journal-remote on Fedora
+# to generate a journal that can be read on EL7 - it used to work (maybe
+# on F23?) but on F24 it does not work - so, have to run systemd-journal-remote
+# in a centos7 container to generate the messages.journal file in a format that
+# can be read by fluentd
+USE_CONTAINER_FOR_JOURNAL_FORMAT=${USE_CONTAINER_FOR_JOURNAL_FORMAT:-true}
 
 if [ "$USE_JOURNAL" = "true" ] ; then
-    rpm -q systemd-journal-gateway || sudo dnf -y install systemd-journal-gateway || \
-        sudo yum -y install systemd-journal-gateway || {
-            echo Error: please install the package systemd-journal-gateway
-            exit 1
-        }
+    if [ "${USE_CONTAINER_FOR_JOURNAL_FORMAT:-}" != true ] ; then
+        test -x /usr/lib/systemd/systemd-journal-remote || \
+            sudo dnf -y install /usr/lib/systemd/systemd-journal-remote || {
+                echo Error: please install the package containing /usr/lib/systemd/systemd-journal-remote
+                exit 1
+            }
+    fi
 fi
 
 for id in `docker ps -q` ; do
@@ -62,7 +72,7 @@ cleanup() {
         if [ $out -ne 0 ] ; then
             ls -R -alrtF $workdir
         fi
-        rm -rf "$workdir"
+#        rm -rf "$workdir"
     fi
 }
 
@@ -93,7 +103,7 @@ wait_until_cmd() {
 # stderr is curl errors
 curl_es() {
     curl --connect-timeout 1 -s \
-       http://${1}:9200/${2}*/${3}\?q=${4}:"${5}""${6:-}"
+       http://${1}:9200/${2}*/${3}\?size=9000\&q=${4}:"${5}""${6:-}"
 }
 
 get_count_from_json() {
@@ -194,9 +204,9 @@ format_journal_message() {
     fac=1
     sev=2
     msg=`printf "%s-$2 $3" $4 $5 1`
-    ts=`get_journal_timestamp`
-    hn=`hostname -s`
     if [ "$1" = "full" ] ; then
+        ts=`get_journal_timestamp`
+        hn=`hostname -s`
         tee -a /tmp/junk <<EOF
 _SOURCE_REALTIME_TIMESTAMP=$ts
 __REALTIME_TIMESTAMP=$ts
@@ -211,6 +221,8 @@ _PID=$$
 MESSAGE=$msg
 _TRANSPORT=stderr
 PRIORITY=3
+UNKNOWN1=1
+UNKNOWN2=2
 EOF
         if [ -n "${6:-}" ] ; then
             tee -a /tmp/junk <<EOF
@@ -249,10 +261,10 @@ get_journal_container_name() {
 }
 
 pushd ../docker-elasticsearch
-./build-image.sh
+ES_VER=$ES_VER ./build-image.sh
 popd
 
-DB_IN_CONTAINER=1 sh -x $testdir/../docker-elasticsearch/run-container.sh
+ES_VER=$ES_VER DB_IN_CONTAINER=1 sh -x $testdir/../docker-elasticsearch/run-container.sh
 
 # make a bunch of container log file names in $datadir
 # name looks like this:
@@ -262,9 +274,9 @@ DB_IN_CONTAINER=1 sh -x $testdir/../docker-elasticsearch/run-container.sh
 # {"log":"here is where the actual output goes\n","stream":"stderr","time":"2016-04-26T17:09:37.759913885Z"}
 # {"log":"another message\n","stream":"stdout","time":"2016-04-26T17:09:38.759913885Z"}
 
-# number of messages per file
+# number of messages per project
 NMESSAGES=${NMESSAGES:-10}
-# number size e.g. log base 10 of $NMESSAGES
+# max number of digits in $NMESSAGES
 NSIZE=${NSIZE:-2}
 # printf format for message number
 NFMT=${NFMT:-"%0${NSIZE}d"}
@@ -279,13 +291,30 @@ n=`expr $MSGSIZE - 36 - 1 - $NSIZE - 1`
 EXTRAFMT=${EXTRAFMT:-"%0${n}d"}
 if [ "$USE_JOURNAL" = "true" ] ; then
     formatter=format_journal_message
-    sysfilter() {
-        /usr/lib/systemd/systemd-journal-remote - -o $systemlog
-    }
+    if [ "${USE_CONTAINER_FOR_JOURNAL_FORMAT:-}" = true ] ; then
+        sysfilter() {
+            cat >> $datadir/journalinput.txt
+        }
+        postprocesssystemlog() {
+            docker build -t viaq/journal-maker:latest journal-maker
+            docker run --privileged -u 0 -e INPUTFILE=/var/log/journalinput.txt -e OUTPUTFILE=/var/log/journal/messages.journal -v $datadir:/var/log viaq/journal-maker:latest
+            sudo chown -R ${USER}:${USER} $datadir/journal
+        }
+    else
+        sysfilter() {
+            /usr/lib/systemd/systemd-journal-remote - -o $systemlog
+        }
+        postprocesssystemlog() {
+            :
+        }
+    fi
 else
     formatter=format_syslog_message
     sysfilter() {
         cat >> $systemlog
+    }
+    postprocesssystemlog() {
+        :
     }
 fi
 while [ $ii -le $NMESSAGES ] ; do
@@ -310,6 +339,8 @@ while [ $ii -le $NMESSAGES ] ; do
     ii=`expr $ii + 1`
 done
 
+postprocesssystemlog
+
 if [ "$USE_FLUENTD" = "true" ] ; then
     pushd ../docker-fluentd
     ./build-image.sh
@@ -317,10 +348,10 @@ if [ "$USE_FLUENTD" = "true" ] ; then
     # copy fluentd config to config dir
     #    cp openshift-fluentd.conf $confdir/fluent.conf
     cp -r openshift-fluentd/* $confdir
-#    cp $fluentd_syslog_input $confdir/syslog-input.conf
-    # run fluentd with the config dir mounted as /etc/fluentd
+    cp $fluentd_syslog_input $confdir/configs.d/dynamic/input-syslog-default-syslog.conf
+    # run fluentd with the config dir mounted as /etc/fluent
     STARTTIME=$(date +%s)
-    collectorid=`docker run -p 5141:5141/udp -v $datadir:/var/log -v $confdir:/etc/fluent --link viaq-elasticsearch -e ES_HOST=viaq-elasticsearch -e OPS_HOST=viaq-elasticsearch -e ES_PORT=9200 -e OPS_PORT=9200 -e JOURNAL_SOURCE=/var/log/journal -e USE_JOURNAL=$USE_JOURNAL -e JOURNAL_READ_FROM_HEAD=true -e SYSLOG_LISTEN_PORT=5141 -d viaq/fluentd:latest`
+    collectorid=`docker run -p 5141:5141/udp -v $datadir:/var/log -v $confdir:/etc/fluent --link viaq-elasticsearch -e ES_HOST=viaq-elasticsearch -e OPS_HOST=viaq-elasticsearch -e ES_PORT=9200 -e OPS_PORT=9200 -e JOURNAL_SOURCE=/var/log/journal -e USE_JOURNAL=$USE_JOURNAL -e JOURNAL_READ_FROM_HEAD=true -e SYSLOG_LISTEN_PORT=5141 -e DEBUG_FLUENTD=${DEBUG_FLUENTD} -e ES_SCHEME=http -e OPS_SCHEME=http -d viaq/fluentd:latest`
 else
     pushd ../docker-rsyslog-collector
     ./build-image.sh
@@ -341,12 +372,12 @@ fi
 count_ge_nmessages() {
     curcount=`curl_es $myhost $myproject _count $myfield "$mymessage" | get_count_from_json`
     echo count $curcount time $(date +%s)
-    test $curcount -ge $NMESSAGES
+    test "${curcount:-0}" -ge $NMESSAGES
 }
 
 echo waiting for $NMESSAGES messages in .operations and $NPROJECTS projects in elasticsearch
 
-myhost=localhost myproject=.operations myfield=ident mymessage=$prefix wait_until_cmd count_ge_nmessages 20 1 || {
+myhost=localhost myproject=.operations myfield=systemd.u.SYSLOG_IDENTIFIER mymessage=$prefix wait_until_cmd count_ge_nmessages 30 1 || {
     echo error: $NMESSAGES messages not found in .operations
     curl_es localhost .operations _search ident $prefix | python -mjson.tool
     exit 1
@@ -355,9 +386,9 @@ myhost=localhost myproject=.operations myfield=ident mymessage=$prefix wait_unti
 iii=1
 while [ $iii -le $NPROJECTS ] ; do
     myproject=`printf "%s${NPFMT}" $projprefix $iii`
-    myhost=localhost myproject=$myproject myfield=message mymessage=$prefix wait_until_cmd count_ge_nmessages 60 1 || {
+    myhost=localhost myproject=project.$myproject myfield=message mymessage=$prefix wait_until_cmd count_ge_nmessages 60 1 || {
         echo error: $NMESSAGES messages not found in $myproject
-        curl_es localhost $myproject _search message $prefix | python -mjson.tool
+        curl_es localhost project.$myproject _search message $prefix | python -mjson.tool
         exit 1
     }
     iii=`expr $iii + 1`


### PR DESCRIPTION
Support for Elasticsearch 2.4.4
large bulk ops can timeout - increase es request timeout
A journal file created on Fedora 24 cannot be read on EL7 - use a
container running el7 to create a journal file for el7
use released version of viaq-data-model filter